### PR TITLE
Install Node.js and Yarn in php-apache container

### DIFF
--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -107,3 +107,13 @@ RUN { \
 } | tee "${PHP_CONFDIR}/pos-finance.ini"
 
 RUN a2enmod rewrite
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        nodejs \
+        yarn \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In order to compile the assets for the browser tests, Node.js and Yarn are required. The command was copied 1:1 from the php-cli docker file.