### PR TITLE
PF-1086 Re-add CMD to PHP Dockerfiles

### DIFF
--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -163,3 +163,5 @@ RUN a2enmod http2 rewrite
 COPY docker-php-entrypoint /usr/local/bin/
 
 ENTRYPOINT [ "docker-php-entrypoint" ]
+
+CMD [ "apache2-foreground" ]

--- a/php-cli/Dockerfile
+++ b/php-cli/Dockerfile
@@ -157,3 +157,5 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
 COPY docker-php-entrypoint /usr/local/bin/
 
 ENTRYPOINT [ "docker-php-entrypoint" ]
+
+CMD [ "php", "-a" ]

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -127,3 +127,5 @@ RUN { \
 COPY docker-php-entrypoint /usr/local/bin/
 
 ENTRYPOINT [ "docker-php-entrypoint" ]
+
+CMD [ "php-fpm" ]


### PR DESCRIPTION
The `CMD` will be nulled by defining an `ENTRYPOINT`, see https://github.com/moby/moby/issues/5147